### PR TITLE
feat: implement firing alerts handler

### DIFF
--- a/internal/handlers/alerts/firing_all.go
+++ b/internal/handlers/alerts/firing_all.go
@@ -1,0 +1,137 @@
+package alerts
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+
+	"csjk-bk/models"
+	alertsapi "csjk-bk/restapi/operations/alerts"
+)
+
+type amAlert struct {
+	Fingerprint string `json:"fingerprint"`
+	Status      struct {
+		State string `json:"state"`
+	} `json:"status"`
+	StartsAt     time.Time         `json:"startsAt"`
+	EndsAt       time.Time         `json:"endsAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+}
+
+// NewGetFiringAlertsAllHandler creates handler for retrieving firing alerts.
+func NewGetFiringAlertsAllHandler(client *http.Client, alertManagerURL string) alertsapi.GetFiringAlertsAllHandler {
+	return alertsapi.GetFiringAlertsAllHandlerFunc(func(params alertsapi.GetFiringAlertsAllParams) middleware.Responder {
+		reqURL := fmt.Sprintf("%s/api/v2/alerts?active=true&inhibited=false&silenced=false&unprocessed=false", alertManagerURL)
+		req, err := http.NewRequestWithContext(params.HTTPRequest.Context(), http.MethodGet, reqURL, nil)
+		if err != nil {
+			return alertsapi.NewGetFiringAlertsAllInternalServerError().WithPayload(&models.StandardResponse{Detail: err.Error()})
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return alertsapi.NewGetFiringAlertsAllInternalServerError().WithPayload(&models.StandardResponse{Detail: err.Error()})
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return alertsapi.NewGetFiringAlertsAllInternalServerError().WithPayload(&models.StandardResponse{Detail: fmt.Sprintf("alertmanager status %s", resp.Status)})
+		}
+
+		var amAlerts []amAlert
+		if err := json.NewDecoder(resp.Body).Decode(&amAlerts); err != nil {
+			return alertsapi.NewGetFiringAlertsAllInternalServerError().WithPayload(&models.StandardResponse{Detail: err.Error()})
+		}
+
+		sort.Slice(amAlerts, func(i, j int) bool {
+			return amAlerts[i].StartsAt.After(amAlerts[j].StartsAt)
+		})
+
+		stats := struct {
+			Inband  map[string]int64
+			Outband map[string]int64
+			Event   map[string]int64
+		}{
+			Inband:  make(map[string]int64),
+			Outband: make(map[string]int64),
+			Event:   make(map[string]int64),
+		}
+
+		for _, a := range amAlerts {
+			class := a.Labels["class"]
+			severity := a.Labels["severity"]
+			switch class {
+			case "inband":
+				stats.Inband[severity]++
+			case "outband":
+				stats.Outband[severity]++
+			case "event":
+				stats.Event[severity]++
+			}
+		}
+
+		total := int64(len(amAlerts))
+		start := int((params.Page - 1) * params.PageSize)
+		end := start + int(params.PageSize)
+		if start > len(amAlerts) {
+			start = len(amAlerts)
+		}
+		if end > len(amAlerts) {
+			end = len(amAlerts)
+		}
+
+		var alertsModel models.Alerts
+		for _, a := range amAlerts[start:end] {
+			alertsModel = append(alertsModel, &models.Alert{
+				Fingerprint:  a.Fingerprint,
+				Status:       a.Status.State,
+				Startsat:     strfmt.DateTime(a.StartsAt),
+				Endsat:       strfmt.DateTime(a.EndsAt),
+				Generatorurl: a.GeneratorURL,
+				Labels:       a.Labels,
+				Annotaions:   a.Annotations,
+			})
+		}
+
+		path := params.HTTPRequest.URL.Path
+		var nextURI, prevURI strfmt.URI
+		if end < len(amAlerts) {
+			v := url.Values{}
+			v.Set("page", strconv.FormatInt(params.Page+1, 10))
+			v.Set("page_size", strconv.FormatInt(params.PageSize, 10))
+			nextURI = strfmt.URI(path + "?" + v.Encode())
+		}
+		if params.Page > 1 {
+			v := url.Values{}
+			v.Set("page", strconv.FormatInt(params.Page-1, 10))
+			v.Set("page_size", strconv.FormatInt(params.PageSize, 10))
+			prevURI = strfmt.URI(path + "?" + v.Encode())
+		}
+
+		payload := &alertsapi.GetFiringAlertsAllOKBody{
+			StandardResponse: models.StandardResponse{
+				Count:    &total,
+				Next:     nextURI,
+				Previous: prevURI,
+			},
+			Results: &alertsapi.GetFiringAlertsAllOKBodyGetFiringAlertsAllOKBodyAO1Results{
+				Statistic: &alertsapi.GetFiringAlertsAllOKBodyGetFiringAlertsAllOKBodyAO1ResultsStatistic{
+					Inband:  stats.Inband,
+					Outband: stats.Outband,
+					Event:   stats.Event,
+				},
+				Alerts: alertsModel,
+			},
+		}
+
+		return alertsapi.NewGetFiringAlertsAllOK().WithPayload(payload)
+	})
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"csjk-bk/models"
+)
+
+// ServeError writes an HTTP 500 response in StandardResponse JSON format.
+func ServeError(rw http.ResponseWriter, _ *http.Request, err error) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(rw).Encode(&models.StandardResponse{Detail: err.Error()})
+}

--- a/restapi/configure_csjk_bk.go
+++ b/restapi/configure_csjk_bk.go
@@ -7,11 +7,10 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/runtime/middleware"
 
+	alertsHandler "csjk-bk/internal/handlers/alerts"
 	"csjk-bk/pkg/errors"
 	"csjk-bk/restapi/operations"
-	"csjk-bk/restapi/operations/alerts"
 )
 
 //go:generate swagger generate server --target ../../csjk-bk --name CsjkBk --spec ../openapi/openapi.yaml --principal interface{}
@@ -22,7 +21,6 @@ func configureFlags(api *operations.CsjkBkAPI) {
 
 func configureAPI(api *operations.CsjkBkAPI) http.Handler {
 	// configure the api here
-	// api.ServeError = errors.ServeError
 	api.ServeError = errors.ServeError
 
 	// Set your custom logger if needed. Default one is log.Printf
@@ -38,19 +36,7 @@ func configureAPI(api *operations.CsjkBkAPI) http.Handler {
 	api.JSONConsumer = runtime.JSONConsumer()
 
 	api.JSONProducer = runtime.JSONProducer()
-
-	if api.AlertsGetFiringAlertsAllHandler == nil {
-		api.AlertsGetFiringAlertsAllHandler = alerts.GetFiringAlertsAllHandlerFunc(func(params alerts.GetFiringAlertsAllParams) middleware.Responder {
-			return middleware.NotImplemented("operation alerts.GetFiringAlertsAll has not yet been implemented")
-		})
-	}
-
-	// api.AlertsGetFiringAlertsAllHandler = alerts.GetFiringAlertsAllHandlerFunc(func(gfaap alerts.GetFiringAlertsAllParams) middleware.Responder {
-	// 	fmt.Printf("%+v\n", gfaap)
-	// 	payload := make(models.Alerts, 0)
-
-	// 	return alerts.NewGetFiringAlertsAllOK().WithPayload(&alerts.GetFiringAlertsAllOKBody{Results: payload})
-	// })
+	api.AlertsGetFiringAlertsAllHandler = alertsHandler.NewGetFiringAlertsAllHandler(http.DefaultClient, "http://alertmanagerip:port")
 
 	api.PreServerShutdown = func() {}
 


### PR DESCRIPTION
## Summary
- add firing alerts handler querying Alertmanager, sorting by start time, aggregating class/severity statistics, and paginating results
- use request context when calling Alertmanager
- return JSON-formatted server errors

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a565b67de0833290afd8199fa4a691