### PR TITLE
Implement alert query filters

### DIFF
--- a/pkg/client/postgres/postgres.go
+++ b/pkg/client/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"csjk-bk/pkg/model/alert"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,29 +26,135 @@ type Client struct {
 // GetAlerts 根据报警筛选条件获取报警信息, 条件默认为并集.
 func (c *Client) GetAlerts(ctx context.Context, from, to time.Time, status []string, labels, annotations map[string][]string, page, pageSize int64) (alert.Alerts, error) {
 	alerts := make(alert.Alerts, 0)
+
 	conn, err := c.pool.Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("无法获取数据库连接: %w", err)
 	}
 	defer conn.Release()
 
-	rows, err := conn.Query(ctx, "SELECT id FROM alert WHERE startsat >= $1 AND startsat <= $2 AND status = ANY($3)", from, to, status)
+	var sb strings.Builder
+	sb.WriteString("SELECT a.id, a.status, a.startsat, a.endsat FROM alert a WHERE 1=1")
+
+	args := make([]interface{}, 0)
+	idx := 1
+
+	if !from.IsZero() {
+		sb.WriteString(fmt.Sprintf(" AND a.startsat >= $%d", idx))
+		args = append(args, from)
+		idx++
+	}
+	if !to.IsZero() {
+		sb.WriteString(fmt.Sprintf(" AND a.startsat <= $%d", idx))
+		args = append(args, to)
+		idx++
+	}
+	if len(status) > 0 {
+		sb.WriteString(fmt.Sprintf(" AND a.status = ANY($%d)", idx))
+		args = append(args, status)
+		idx++
+	}
+
+	for k, vals := range labels {
+		if len(vals) == 0 {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf(" AND EXISTS (SELECT 1 FROM alertlabel al WHERE al.alertid = a.id AND al.label = $%d AND al.value = ANY($%d))", idx, idx+1))
+		args = append(args, k, vals)
+		idx += 2
+	}
+
+	for k, vals := range annotations {
+		if len(vals) == 0 {
+			continue
+		}
+		patterns := make([]string, 0, len(vals))
+		for _, v := range vals {
+			patterns = append(patterns, "%"+v+"%")
+		}
+		sb.WriteString(fmt.Sprintf(" AND EXISTS (SELECT 1 FROM alertannotation an WHERE an.alertid = a.id AND an.annotation = $%d AND an.value ILIKE ANY($%d))", idx, idx+1))
+		args = append(args, k, patterns)
+		idx += 2
+	}
+
+	sb.WriteString(" ORDER BY a.startsat DESC")
+	if pageSize > 0 {
+		sb.WriteString(fmt.Sprintf(" LIMIT $%d", idx))
+		args = append(args, pageSize)
+		idx++
+		if page > 0 {
+			sb.WriteString(fmt.Sprintf(" OFFSET $%d", idx))
+			args = append(args, (page-1)*pageSize)
+			idx++
+		}
+	}
+
+	rows, err := conn.Query(ctx, sb.String(), args...)
 	if err != nil {
 		return nil, fmt.Errorf("查询数据库失败: %w", err)
 	}
+	defer rows.Close()
 
+	idMap := make(map[int64]*alert.Alert)
 	ids := make([]int64, 0)
 	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
+		a := &alert.Alert{Label: make(map[string]string), Annotation: make(map[string]string)}
+		if err := rows.Scan(&a.ID, &a.Status, &a.StartsAt, &a.EndsAt); err != nil {
+			return nil, fmt.Errorf("读取数据失败: %w", err)
 		}
-		ids = append(ids, id)
+		alerts = append(alerts, a)
+		idMap[a.ID] = a
+		ids = append(ids, a.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("读取数据失败: %w", err)
 	}
 
-	// 筛标签
-	// SELECT alertid FROM alertlabel WHERE
-	// (label = ? AND key = ANY($))
+	if len(ids) == 0 {
+		return alerts, nil
+	}
+
+	lrows, err := conn.Query(ctx, "SELECT alertid, label, value FROM alertlabel WHERE alertid = ANY($1)", ids)
+	if err != nil {
+		return nil, fmt.Errorf("查询数据库失败: %w", err)
+	}
+	for lrows.Next() {
+		var id int64
+		var k, v string
+		if err := lrows.Scan(&id, &k, &v); err != nil {
+			lrows.Close()
+			return nil, fmt.Errorf("读取数据失败: %w", err)
+		}
+		if al, ok := idMap[id]; ok {
+			al.Label[k] = v
+		}
+	}
+	if err := lrows.Err(); err != nil {
+		lrows.Close()
+		return nil, fmt.Errorf("读取数据失败: %w", err)
+	}
+	lrows.Close()
+
+	arows, err := conn.Query(ctx, "SELECT alertid, annotation, value FROM alertannotation WHERE alertid = ANY($1)", ids)
+	if err != nil {
+		return nil, fmt.Errorf("查询数据库失败: %w", err)
+	}
+	for arows.Next() {
+		var id int64
+		var k, v string
+		if err := arows.Scan(&id, &k, &v); err != nil {
+			arows.Close()
+			return nil, fmt.Errorf("读取数据失败: %w", err)
+		}
+		if al, ok := idMap[id]; ok {
+			al.Annotation[k] = v
+		}
+	}
+	if err := arows.Err(); err != nil {
+		arows.Close()
+		return nil, fmt.Errorf("读取数据失败: %w", err)
+	}
+	arows.Close()
 
 	return alerts, nil
 }

--- a/pkg/errors/api.go
+++ b/pkg/errors/api.go
@@ -88,7 +88,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 		rw.Header().Add("Allow", strings.Join(e.Allowed, ","))
 		rw.WriteHeader(asHTTPCode(int(e.Code())))
 		if r == nil || r.Method != http.MethodHead {
-			_, _ = rw.Write(errorAsJSON(New(e.Error())))
+			_, _ = rw.Write(errorAsJSON(New("%s", e.Error())))
 		}
 	case errors.Error:
 		fmt.Println(e.Code(), e.Error())
@@ -100,7 +100,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 		}
 		rw.WriteHeader(asHTTPCode(int(e.Code())))
 		if r == nil || r.Method != http.MethodHead {
-			_, _ = rw.Write(errorAsJSON(New(e.Error())))
+			_, _ = rw.Write(errorAsJSON(New("%s", e.Error())))
 		}
 	case nil:
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -108,7 +108,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 	default:
 		rw.WriteHeader(http.StatusInternalServerError)
 		if r == nil || r.Method != http.MethodHead {
-			_, _ = rw.Write(errorAsJSON(New(err.Error())))
+			_, _ = rw.Write(errorAsJSON(New("%s", err.Error())))
 		}
 	}
 }

--- a/pkg/model/alert/alert.go
+++ b/pkg/model/alert/alert.go
@@ -2,7 +2,8 @@ package alert
 
 import "time"
 
-type Alerts []*Alerts
+// Alerts represents a list of Alert pointers.
+type Alerts []*Alert
 
 type Alert struct {
 	ID         int64


### PR DESCRIPTION
## Summary
- implement GetAlerts to query alerts by status, time range, labels, annotations, and pagination
- fix Alert slice type and format-safe error wrapping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5356c287c8332893ecdbe3bb603ae