### PR TITLE
feat(alerts): support update operation

### DIFF
--- a/internal/handlers/alerts/alerts.go
+++ b/internal/handlers/alerts/alerts.go
@@ -235,6 +235,29 @@ func NewGetAlertLabelValues(client *postgres.Client) alertsapi.GetAlertLabelValu
 	})
 }
 
+// NewPutAlertOperation 更新报警处理人和处理方式.
+func NewPutAlertOperation(client *postgres.Client) alertsapi.PutAlertOperationHandler {
+	return alertsapi.PutAlertOperationHandlerFunc(func(pao alertsapi.PutAlertOperationParams) middleware.Responder {
+		ctx := pao.HTTPRequest.Context()
+
+		if err := client.SetOperation(ctx, *pao.Body.Ids, *pao.Body.Operation, *pao.Body.Responder); err != nil {
+			return alertsapi.NewPutAlertOperationInternalServerError().WithPayload(&models.StandardResponse{Detail: utils.StringPtr("更新报警处理信息失败")})
+		}
+
+		var emptyURI strfmt.URI
+		count := int64(-1)
+		payload := &models.StandardResponse{
+			Count:    &count,
+			Next:     &emptyURI,
+			Previous: &emptyURI,
+			Results:  struct{}{},
+			Detail:   utils.StringPtr("更新报警处理信息成功"),
+		}
+
+		return alertsapi.NewPutAlertOperationOK().WithPayload(payload)
+	})
+}
+
 type Alerts []Alert
 
 type Alert struct {

--- a/pkg/client/postgres/postgres.go
+++ b/pkg/client/postgres/postgres.go
@@ -220,3 +220,16 @@ func (c *Client) GetAlertLabelValues(ctx context.Context, label string) ([]strin
 	}
 	return values, nil
 }
+
+// SetOperation 更新指定报警的处理方式和处理人.
+func (c *Client) SetOperation(ctx context.Context, id int64, operation, responder string) error {
+	cmd := "UPDATE alert SET operation = $1, responder = $2 WHERE id = $3"
+	tag, err := c.pool.Exec(ctx, cmd, operation, responder, id)
+	if err != nil {
+		return fmt.Errorf("更新数据库失败: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("未找到报警 ID %d", id)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add postgres client method to update alert responder and operation
- implement handler for /alerts/operation API using new client method

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5473e716c8332a065212ba7da9fdb